### PR TITLE
Remove references to email

### DIFF
--- a/_includes/contact.html
+++ b/_includes/contact.html
@@ -1,10 +1,6 @@
 <main class="container">
     <div class="jumbotron jumbotron-fluid col-lg-6 offset-lg-3 py-2 col-sm-12">
         <div class="container my-0">
-            <h3 class="display-5">Email</h3>
-            <p class="lead pl-4">
-                <a href="mailto:wmboyles@wmboyles.com">wmboyles@wmboyles.com</a>
-            </p>
             <h3 class="display-5">Github</h3>
             <p class="lead pl-4">
                 <a href="https://www.github.com/wmboyles">wmboyles</a>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -3,9 +3,6 @@
     <div class="container">
         <p class="m-0 text-center text-white">© William Boyles 2023</p>
         <div class="container text-center" id="icons">
-            <a href="mailto:wmboyles@wmboyles.com" target="_blank">
-                <i class="footer-icon fas fa-at"></i>
-            </a>
             <a href="https://www.github.com/wmboyles/" target="_blank">
                 <i class="footer-icon fab fa-github"></i>
             </a>


### PR DESCRIPTION
When the site was in Google Domains, there was a free integration with Gmail that allowed me to have all mail sent to any address ending in `@wmboyles.com` to be forwarded to my personal email address, where I could also respond using this address. This feature was nice for anonymizing myself and having a professional-looking email address.

As I mentioned in https://github.com/wmboyles/wmboyles.com/issues/11, I wasn't able to get receiving email working at my domain in Azure. So, my options are either to replace the references to my anonymized email address with my personal one, or to remove email addresses entirely. Before I found the Gmail integration, I did the first option. To this day, I still get spam messages about my site. So, I think I'd prefer to take it down. I'll consider whether to update or remove my address in other places like my resume separately.